### PR TITLE
Introduce shared docker_client fixture

### DIFF
--- a/molecule/deploy/tests/conftest.py
+++ b/molecule/deploy/tests/conftest.py
@@ -1,0 +1,10 @@
+import docker
+import pytest
+
+@pytest.fixture
+def docker_client():
+    client = docker.from_env()
+    try:
+        yield client
+    finally:
+        client.close()

--- a/molecule/deploy/tests/test_configfile_deployment.py
+++ b/molecule/deploy/tests/test_configfile_deployment.py
@@ -53,9 +53,9 @@ class TestConfigFileDeployment:
 class TestVolumeToDirectoryMapping:
     """Test suite for volume to directory mapping functionality (vols2dirs.yml)"""
 
-    def test_bind_mount_sources_created(self, host):
+    def test_bind_mount_sources_created(self, host, docker_client):
         """Test that bind mount source directories/files are created"""
-        client = docker.from_env()
+        client = docker_client
 
         try:
             container = client.containers.get('testapp')
@@ -79,9 +79,9 @@ class TestVolumeToDirectoryMapping:
             # Log for debugging
             print(f"Mount: {source_path} -> {destination_path}")
 
-    def test_volume_path_parsing(self, host):
+    def test_volume_path_parsing(self, host, docker_client):
         """Test that volume path parsing works correctly"""
-        client = docker.from_env()
+        client = docker_client
 
         try:
             container = client.containers.get('testapp')
@@ -122,10 +122,10 @@ class TestVolumeToDirectoryMapping:
 class TestConfigListProcessing:
     """Test suite for configuration list processing"""
 
-    def test_config_file_deployment_from_list(self, host):
+    def test_config_file_deployment_from_list(self, host, docker_client):
         """Test that config files are deployed according to configlist variable"""
         # This tests the configfiles.yml functionality
-        client = docker.from_env()
+        client = docker_client
 
         try:
             container = client.containers.get('testapp')

--- a/molecule/deploy/tests/test_edge_cases.py
+++ b/molecule/deploy/tests/test_edge_cases.py
@@ -17,9 +17,9 @@ def get_container(client, name):
 class TestEdgeCases:
     """Test suite for edge cases and error conditions"""
     
-    def test_container_names_are_unique(self):
+    def test_container_names_are_unique(self, docker_client):
         """Test that container names don't conflict"""
-        client = docker.from_env()
+        client = docker_client
         containers = client.containers.list(all=True)
         
         # Get containers created by our test
@@ -33,9 +33,9 @@ class TestEdgeCases:
         assert 'testapp' in container_names, "Main container 'testapp' not found"
         assert 'redis' in container_names, "Dependency container 'redis' not found"
     
-    def test_container_resource_limits(self):
+    def test_container_resource_limits(self, docker_client):
         """Test that containers don't have unexpected resource limits"""
-        client = docker.from_env()
+        client = docker_client
         
         for container_name in ['testapp', 'redis']:
             container = get_container(client, container_name)
@@ -48,9 +48,9 @@ class TestEdgeCases:
             # In our test setup, we don't set memory limits
             assert memory_limit == 0, f"Container {container_name} has unexpected memory limit: {memory_limit}"
     
-    def test_container_network_mode(self):
+    def test_container_network_mode(self, docker_client):
         """Test that containers use expected network mode"""
-        client = docker.from_env()
+        client = docker_client
         
         # Test main container uses custom network
         testapp = get_container(client, 'testapp')
@@ -72,9 +72,9 @@ class TestEdgeCases:
             network_mode = container.attrs['HostConfig']['NetworkMode']
             assert network_mode in ['default', 'bridge'], f"Container {container_name} has unexpected network mode: {network_mode}"
 
-    def test_container_environment_variables(self):
+    def test_container_environment_variables(self, docker_client):
         """Test that containers have expected environment variables"""
-        client = docker.from_env()
+        client = docker_client
         
         # Test main container
         testapp = get_container(client, 'testapp')
@@ -106,9 +106,9 @@ class TestEdgeCases:
 class TestConfigurationValidation:
     """Test suite for configuration validation"""
     
-    def test_volume_mount_permissions(self):
+    def test_volume_mount_permissions(self, docker_client):
         """Test that volume mounts have correct permissions"""
-        client = docker.from_env()
+        client = docker_client
         container = get_container(client, 'testapp')
         assert container is not None
         
@@ -119,9 +119,9 @@ class TestConfigurationValidation:
                 # Check that mount has read/write access by default
                 assert mount['RW'] == True, f"Mount {mount['Destination']} is not read-write"
     
-    def test_container_working_directory(self):
+    def test_container_working_directory(self, docker_client):
         """Test that containers have appropriate working directories"""
-        client = docker.from_env()
+        client = docker_client
         
         # Test main container
         testapp = get_container(client, 'testapp')
@@ -131,9 +131,9 @@ class TestConfigurationValidation:
         # Nginx container typically uses /
         assert working_dir in ['/', ''], f"Unexpected working directory for testapp: {working_dir}"
     
-    def test_container_user_configuration(self):
+    def test_container_user_configuration(self, docker_client):
         """Test that containers run with appropriate user configuration"""
-        client = docker.from_env()
+        client = docker_client
         
         for container_name in ['testapp', 'redis']:
             container = get_container(client, container_name)

--- a/molecule/deploy/tests/test_enhanced_features.py
+++ b/molecule/deploy/tests/test_enhanced_features.py
@@ -13,9 +13,9 @@ def get_container(client, name):
 class TestEnhancedContainerFeatures:
     """Test suite for enhanced container features and dependencies"""
 
-    def test_all_dependency_containers_running(self):
+    def test_all_dependency_containers_running(self, docker_client):
         """Test that all dependency containers are running"""
-        client = docker.from_env()
+        client = docker_client
 
         expected_containers = ['testapp', 'redis', 'postgres']
         for container_name in expected_containers:
@@ -23,9 +23,9 @@ class TestEnhancedContainerFeatures:
             assert container is not None, f"Container {container_name} not found"
             assert container.status == 'running', f"Container {container_name} is not running"
 
-    def test_postgres_container_configuration(self):
+    def test_postgres_container_configuration(self, docker_client):
         """Test PostgreSQL container specific configuration"""
-        client = docker.from_env()
+        client = docker_client
         container = get_container(client, 'postgres')
         assert container is not None
 
@@ -51,9 +51,9 @@ class TestEnhancedContainerFeatures:
         assert '5432/tcp' in port_bindings, "PostgreSQL port 5432/tcp not bound"
         assert port_bindings['5432/tcp'][0]['HostPort'] == '5432', "PostgreSQL port not mapped correctly"
 
-    def test_redis_container_configuration(self):
+    def test_redis_container_configuration(self, docker_client):
         """Test Redis container specific configuration"""
-        client = docker.from_env()
+        client = docker_client
         container = get_container(client, 'redis')
         assert container is not None
 
@@ -74,9 +74,9 @@ class TestEnhancedContainerFeatures:
 class TestContainerLabels:
     """Test suite for container labels"""
 
-    def test_main_container_labels(self):
+    def test_main_container_labels(self, docker_client):
         """Test that main container has correct labels"""
-        client = docker.from_env()
+        client = docker_client
         container = get_container(client, 'testapp')
         assert container is not None
 
@@ -89,9 +89,9 @@ class TestContainerLabels:
         assert 'version' in labels, "Version label not found"
         assert labels['version'] == '1.0', f"Version label incorrect: {labels['version']}"
 
-    def test_dependency_container_labels(self):
+    def test_dependency_container_labels(self, docker_client):
         """Test that dependency containers have correct labels"""
-        client = docker.from_env()
+        client = docker_client
 
         # Test Redis labels
         redis = get_container(client, 'redis')
@@ -115,9 +115,9 @@ class TestContainerLabels:
 class TestContainerEnvironmentVariables:
     """Test suite for container environment variables"""
 
-    def test_main_container_environment_variables(self):
+    def test_main_container_environment_variables(self, docker_client):
         """Test that main container has correct environment variables"""
-        client = docker.from_env()
+        client = docker_client
         container = get_container(client, 'testapp')
         assert container is not None
 
@@ -137,9 +137,9 @@ class TestContainerEnvironmentVariables:
 class TestContainerNetworking:
     """Test suite for container networking"""
 
-    def test_containers_on_custom_network(self):
+    def test_containers_on_custom_network(self, docker_client):
         """Test that containers are connected to custom network"""
-        client = docker.from_env()
+        client = docker_client
 
         # Check if the custom network exists
         try:
@@ -161,9 +161,9 @@ class TestContainerNetworking:
 class TestVolumeManagement:
     """Test suite for volume management and directory creation"""
 
-    def test_additional_volumes_mounted(self):
+    def test_additional_volumes_mounted(self, docker_client):
         """Test that additional volumes are properly mounted"""
-        client = docker.from_env()
+        client = docker_client
         container = get_container(client, 'testapp')
         assert container is not None
 
@@ -237,9 +237,9 @@ class TestFinishCommands:
 class TestContainerPullAndRecreate:
     """Test suite for container pull and recreate settings"""
 
-    def test_container_pull_settings(self):
+    def test_container_pull_settings(self, docker_client):
         """Test that containers were created with correct pull settings"""
-        client = docker.from_env()
+        client = docker_client
 
         # This is more of a verification that the role accepted the pull parameter
         # The actual pulling behavior is harder to test in molecule
@@ -249,9 +249,9 @@ class TestContainerPullAndRecreate:
         # Verify the container was created (pull worked)
         assert container.status == 'running', "Container should be running if pull succeeded"
 
-    def test_container_recreate_settings(self):
+    def test_container_recreate_settings(self, docker_client):
         """Test that containers respect recreate settings"""
-        client = docker.from_env()
+        client = docker_client
 
         # With recreate: false, the container should exist and be running
         container = get_container(client, 'testapp')


### PR DESCRIPTION
## Summary
- add `docker_client` fixture for Molecule tests
- update test files to use the fixture

## Testing
- `pytest -q` *(fails: KeyError: 'MOLECULE_INVENTORY_FILE')*

------
https://chatgpt.com/codex/tasks/task_e_6889eddcde4883229058d0275f49221c